### PR TITLE
Pay Extraordinary Developer Expenses: Cover shipping

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -66,7 +66,9 @@
 
         \Track Time\  <Developer> agrees to record all time spent on work under this agreement in fairly rounded, quarter-hour increments.
 
-        \Term of Developer's Obligations\  The following <Developer> obligations continue after this agreement ends: {Cover Basic Expenses}, {Make Up Missed Work}
+        \Return Loaned Equipment\  Once this agreement ends, <Developer> agrees to promptly return any equipment the <Client> loaned for work under this agreement.
+
+        \Term of Developer's Obligations\  The following <Developer> obligations continue after this agreement ends: {Cover Basic Expenses}, {Make Up Missed Work}, {Return Loaned Equipment}
 
     \Term\  This agreement starts when <Developer> receives full payment of the <Fee>, and continues until the <Deadline>.
 

--- a/terms.cform
+++ b/terms.cform
@@ -32,7 +32,7 @@
 
         \Pay the Fee\  <Client> agrees to pay the entire <Fee> within [Payment Deadline] of entering this agreement.
 
-        \Pay Extraordinary Developer Expenses\  If <Client> assigns <Developer> work that requires extraordinary equipment, licenses, or services, then <Client> agrees to pay the costs for <Developer> directly.  For example, <Client> agrees to cover the costs of proprietary software licenses, testing hardware, and specific online services that <Client> specifically requires <Developer> to use.  If <Client> cannot pay a cost directly, <Client> agrees to advance <Developer> the cost.  See {Cover Basic Expenses} for <Developer>'s obligation to cover other expenses.
+        \Pay Extraordinary Developer Expenses\  If <Client> assigns <Developer> work that requires extraordinary equipment, licenses, or services, then <Client> agrees to pay the costs for <Developer> directly.  For example, <Client> agrees to cover the costs of proprietary software licenses, testing hardware, and specific online services that <Client> specifically requires <Developer> to use.  If <Client> requires <Developer> to use and return specific equipment, <Client> agrees to cover the costs of packaging and shipping, both ways.  If <Client> cannot pay a cost directly, <Client> agrees to advance <Developer> the cost.  See {Cover Basic Expenses} for <Developer>'s obligation to cover other expenses.
 
         \Use the Agreed Payment Method\  <Client> agrees to make all payments under this agreement via the <Payment Method>.
 

--- a/terms.md
+++ b/terms.md
@@ -38,7 +38,7 @@ _Client_ agrees to pay the entire _Fee_ within seven calendar days of entering t
 
 ### <a id="Pay_Extraordinary_Developer_Expenses"></a>Pay Extraordinary Developer Expenses
 
-If _Client_ assigns _Developer_ work that requires extraordinary equipment, licenses, or services, then _Client_ agrees to pay the costs for _Developer_ directly. For example, _Client_ agrees to cover the costs of proprietary software licenses, testing hardware, and specific online services that _Client_ specifically requires _Developer_ to use. If _Client_ cannot pay a cost directly, _Client_ agrees to advance _Developer_ the cost. See [Cover Basic Expenses](#Cover_Basic_Expenses) for _Developer_'s obligation to cover other expenses.
+If _Client_ assigns _Developer_ work that requires extraordinary equipment, licenses, or services, then _Client_ agrees to pay the costs for _Developer_ directly. For example, _Client_ agrees to cover the costs of proprietary software licenses, testing hardware, and specific online services that _Client_ specifically requires _Developer_ to use. If _Client_ requires _Developer_ to use and return specific equipment, _Client_ agrees to cover the costs of packaging and shipping, both ways. If _Client_ cannot pay a cost directly, _Client_ agrees to advance _Developer_ the cost. See [Cover Basic Expenses](#Cover_Basic_Expenses) for _Developer_'s obligation to cover other expenses.
 
 ### <a id="Use_the_Agreed_Payment_Method"></a>Use the Agreed Payment Method
 

--- a/terms.md
+++ b/terms.md
@@ -102,9 +102,13 @@ _Developer_ agrees to e-mail the _Technical Representative_ the number of _Unuse
 
 _Developer_ agrees to record all time spent on work under this agreement in fairly rounded, quarter-hour increments.
 
+### <a id="Return_Loaned_Equipment"></a>Return Loaned Equipment
+
+Once this agreement ends, _Developer_ agrees to promptly return any equipment the _Client_ loaned for work under this agreement.
+
 ### <a id="Term_of_Developer's_Obligations"></a>Term of Developer's Obligations
 
-The following _Developer_ obligations continue after this agreement ends: [Cover Basic Expenses](#Cover_Basic_Expenses), [Make Up Missed Work](#Make_Up_Missed_Work)
+The following _Developer_ obligations continue after this agreement ends: [Cover Basic Expenses](#Cover_Basic_Expenses), [Make Up Missed Work](#Make_Up_Missed_Work), [Return Loaned Equipment](#Return_Loaned_Equipment)
 
 ## <a id="Term"></a>Term
 


### PR DESCRIPTION
@bhilburn, here's a proposed edit requiring the client to pay shipping and packaging for any specific equipment the developer needs, both ways.