### PR TITLE
Cover Basic Expenses: Cover things needed in Scope

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -58,7 +58,7 @@
 
         \No Piling On\  The purpose of {Written Instructions} and {Prior Work Done} is to prevent <Client> from piling on new work shortly before the <Deadline>.
 
-        \Cover Basic Expenses\  <Developer> agrees to pay for all equipment, licenses, and services needed to do open software development generally.  For example, <Developer> agrees to provide their own computer, operating system, editor software, and Internet access.  See {Pay Extraordinary Developer Expenses} for <Client>'s obligation to cover other expenses.
+        \Cover Basic Expenses\  <Developer> agrees to pay for all equipment, licenses, and services needed to do open software development in <Scope>, generally.  For example, <Developer> agrees to provide their own computer, operating system, editor software, and Internet access.  See {Pay Extraordinary Developer Expenses} for <Client>'s obligation to cover other expenses.
 
         \Make Up Missed Work\  If <Developer> is unable do work with remaining <Purchased Hours> before the <Deadline> because <Developer> does not work on a <Working Day> due to medical reasons or personal emergency, <Developer> agrees to do that work after the <Deadline>.
 

--- a/terms.md
+++ b/terms.md
@@ -88,7 +88,7 @@ The purpose of [Written Instructions](#Written_Instructions) and [Prior Work Don
 
 ### <a id="Cover_Basic_Expenses"></a>Cover Basic Expenses
 
-_Developer_ agrees to pay for all equipment, licenses, and services needed to do open software development generally. For example, _Developer_ agrees to provide their own computer, operating system, editor software, and Internet access. See [Pay Extraordinary Developer Expenses](#Pay_Extraordinary_Developer_Expenses) for _Client_'s obligation to cover other expenses.
+_Developer_ agrees to pay for all equipment, licenses, and services needed to do open software development in _Scope_, generally. For example, _Developer_ agrees to provide their own computer, operating system, editor software, and Internet access. See [Pay Extraordinary Developer Expenses](#Pay_Extraordinary_Developer_Expenses) for _Client_'s obligation to cover other expenses.
 
 ### <a id="Make_Up_Missed_Work"></a>Make Up Missed Work
 


### PR DESCRIPTION
@bhilburn, what do you think of this change?  I see this as balancing #2.

For example, if the kind of open development the developer does is hardware-intensive, and test equipment is as essential to that work as a text editor, this change would require the developer to provide their own test equipment. However, if the client requires the developer to use really extraordinary test equipment, like a really high-spec RF equipment, they'd either have to cover that cost, or cover the cost of shipping one to the developer and back.