### PR TITLE
Public Licenses: Restructure to emphasize Blue Oak default

### DIFF
--- a/terms.cform
+++ b/terms.cform
@@ -76,7 +76,7 @@
 
         \Public Licenses\  <Developer> licenses work that they create doing work under this agreement to the public at large, including <Client>.  The license terms for each separately licensable work are as follows:
 
-            \Blue Oak By Default\  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+            \Blue Oak By Default\  In general, with the exceptions of {Copyleft When Required} and {Match Existing Licenses}, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
             \Copyleft When Required\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
 

--- a/terms.cform
+++ b/terms.cform
@@ -76,11 +76,11 @@
 
         \Public Licenses\  <Developer> licenses work that they create doing work under this agreement to the public at large, including <Client>.  The license terms for each separately licensable work are as follows:
 
-            \\  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+            \Blue Oak By Default\  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
-            \\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+            \Copyleft When Required\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
 
-            \\  If the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
+            \Match Existing Licenses\  If the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
 
         \Separate Licenses\  Terms under which <Developer> grants licenses under {Public Licenses} will be interpreted as entirely independent legal documents, without reference to these terms or the circumstances of <Developer> and <Client>'s agreement.  The purpose of this rule is to allow <Developer> and <Client> to rely on guidance about standardized terms.
 

--- a/terms.cform
+++ b/terms.cform
@@ -78,7 +78,7 @@
 
             \Blue Oak By Default\  In general, with the exceptions of {Copyleft When Required} and {Match Existing Licenses}, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
-            \Copyleft When Required\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+            \Copyleft When Required\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the terms required.
 
             \Match Existing Licenses\  If the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
 

--- a/terms.cform
+++ b/terms.cform
@@ -82,6 +82,8 @@
 
             \Match Existing Licenses\  If the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
 
+            \Client Licensed Projects\  {Copyleft When Required} and {Match Existing Licenses} do not apply when <Client> grants the relevant <Public License>, and that <Public License> is a copyleft license.
+
         \Separate Licenses\  Terms under which <Developer> grants licenses under {Public Licenses} will be interpreted as entirely independent legal documents, without reference to these terms or the circumstances of <Developer> and <Client>'s agreement.  The purpose of this rule is to allow <Developer> and <Client> to rely on guidance about standardized terms.
 
         \Enforcement of Public Licenses\  Others who are not parties to this agreement may enforce the terms of {Public Licenses}.

--- a/terms.cform
+++ b/terms.cform
@@ -76,11 +76,11 @@
 
         \Public Licenses\  <Developer> licenses work that they create doing work under this agreement to the public at large, including <Client>.  The license terms for each separately licensable work are as follows:
 
+            \\  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+
             \\  If the terms of a <Public License>, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
 
-            \\  Otherwise, if the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
-
-            \\  As a fallback, the terms are those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+            \\  If the work is made up of changes or additions to existing software made available under a standardized <Public License>, the terms are those of that <Public License>.
 
         \Separate Licenses\  Terms under which <Developer> grants licenses under {Public Licenses} will be interpreted as entirely independent legal documents, without reference to these terms or the circumstances of <Developer> and <Client>'s agreement.  The purpose of this rule is to allow <Developer> and <Client> to rely on guidance about standardized terms.
 

--- a/terms.md
+++ b/terms.md
@@ -132,6 +132,10 @@ If the terms of a _Public License_, such as a copyleft license, require the work
 
 If the work is made up of changes or additions to existing software made available under a standardized _Public License_, the terms are those of that _Public License_.
 
+#### <a id="Client_Licensed_Projects"></a>Client Licensed Projects
+
+[Copyleft When Required](#Copyleft_When_Required) and [Match Existing Licenses](#Match_Existing_Licenses) do not apply when _Client_ grants the relevant _Public License_, and that _Public License_ is a copyleft license.
+
 ### <a id="Separate_Licenses"></a>Separate Licenses
 
 Terms under which _Developer_ grants licenses under [Public Licenses](#Public_Licenses) will be interpreted as entirely independent legal documents, without reference to these terms or the circumstances of _Developer_ and _Client_'s agreement. The purpose of this rule is to allow _Developer_ and _Client_ to rely on guidance about standardized terms.

--- a/terms.md
+++ b/terms.md
@@ -120,11 +120,11 @@ This agreement does not assign any _Intellectual Property Right_, and no work un
 
 _Developer_ licenses work that they create doing work under this agreement to the public at large, including _Client_. The license terms for each separately licensable work are as follows:
 
-1.  If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+1.  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
-2.  Otherwise, if the work is made up of changes or additions to existing software made available under a standardized _Public License_, the terms are those of that _Public License_.
+2.  If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
 
-3.  As a fallback, the terms are those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+3.  If the work is made up of changes or additions to existing software made available under a standardized _Public License_, the terms are those of that _Public License_.
 
 ### <a id="Separate_Licenses"></a>Separate Licenses
 

--- a/terms.md
+++ b/terms.md
@@ -120,11 +120,17 @@ This agreement does not assign any _Intellectual Property Right_, and no work un
 
 _Developer_ licenses work that they create doing work under this agreement to the public at large, including _Client_. The license terms for each separately licensable work are as follows:
 
-1.  In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+#### <a id="Blue_Oak_By_Default"></a>Blue Oak By Default
 
-2.  If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
-3.  If the work is made up of changes or additions to existing software made available under a standardized _Public License_, the terms are those of that _Public License_.
+#### <a id="Copyleft_When_Required"></a>Copyleft When Required
+
+If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+
+#### <a id="Match_Existing_Licenses"></a>Match Existing Licenses
+
+If the work is made up of changes or additions to existing software made available under a standardized _Public License_, the terms are those of that _Public License_.
 
 ### <a id="Separate_Licenses"></a>Separate Licenses
 

--- a/terms.md
+++ b/terms.md
@@ -126,7 +126,7 @@ In general, with the exceptions of [Copyleft When Required](#Copyleft_When_Requi
 
 #### <a id="Copyleft_When_Required"></a>Copyleft When Required
 
-If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the most permissive terms possible that meet that requirement.
+If the terms of a _Public License_, such as a copyleft license, require the work be licensed under particular terms, the terms for that work are the terms required.
 
 #### <a id="Match_Existing_Licenses"></a>Match Existing Licenses
 

--- a/terms.md
+++ b/terms.md
@@ -122,7 +122,7 @@ _Developer_ licenses work that they create doing work under this agreement to th
 
 #### <a id="Blue_Oak_By_Default"></a>Blue Oak By Default
 
-In general, with the two exceptions that follow, the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
+In general, with the exceptions of [Copyleft When Required](#Copyleft_When_Required) and [Match Existing Licenses](#Match_Existing_Licenses), the terms will be those of the latest version of The Blue Oak Model License published on blueoakcouncil.org.
 
 #### <a id="Copyleft_When_Required"></a>Copyleft When Required
 


### PR DESCRIPTION
@bhilburn, this "refactoring" emphasizes that Blue Oak is the default license for new work.